### PR TITLE
Add progress bar and fetch button

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ c.GalleryManager.exhibits = [
         "git": "https://github.com/jupyterlab/jupyterlab.git",
         "repository": "https://github.com/jupyterlab/jupyterlab/",
         "title": "JupyterLab",
-        "description": "JupyterLab",
+        "description": "JupyterLab is a highly extensible, feature-rich notebook authoring application and editing environment.",
         "icon": "https://raw.githubusercontent.com/jupyterlab/jupyterlab/main/packages/ui-components/style/icons/jupyter/jupyter.svg"
     }
 ]

--- a/jupyterlab_gallery/gitpuller.py
+++ b/jupyterlab_gallery/gitpuller.py
@@ -7,6 +7,7 @@
 # - reconnecting to the event stream when refreshing the browser
 # - handling multiple waiting pulls
 from tornado import gen, web, locks
+import logging
 import traceback
 
 import threading
@@ -15,8 +16,68 @@ import os
 from queue import Queue, Empty
 from collections import defaultdict
 
+import git
 from jupyter_server.base.handlers import JupyterHandler
 from nbgitpuller.pull import GitPuller
+from numbers import Number
+
+
+class CloneProgress(git.RemoteProgress):
+    def __init__(self):
+        self.queue = Queue()
+        self.max_stage = 0.01
+        self.prev_stage = 0
+        super().__init__()
+
+    def update(self, op_code: int, cur_count, max_count=None, message=""):
+        if op_code & git.RemoteProgress.BEGIN:
+            new_stage = None
+            if op_code & git.RemoteProgress.COUNTING:
+                new_stage = 0.05
+            elif op_code & git.RemoteProgress.COMPRESSING:
+                new_stage = 0.10
+            elif op_code & git.RemoteProgress.RECEIVING:
+                new_stage = 0.90
+            elif op_code & git.RemoteProgress.RESOLVING:
+                new_stage = 1
+
+            if new_stage:
+                self.prev_stage = self.max_stage
+                self.max_stage = new_stage
+
+        if isinstance(cur_count, Number) and isinstance(max_count, Number):
+            self.queue.put(
+                {
+                    "progress": self.prev_stage
+                    + cur_count / max_count * (self.max_stage - self.prev_stage),
+                    "message": message,
+                }
+            )
+            # self.queue.join()
+
+
+class ProgressGitPuller(GitPuller):
+    def initialize_repo(self):
+        logging.info("Repo {} doesn't exist. Cloning...".format(self.repo_dir))
+        progress = CloneProgress()
+
+        def clone_task():
+            git.Repo.clone_from(
+                self.git_url, self.repo_dir, branch=self.branch_name, progress=progress
+            )
+            progress.queue.put(None)
+
+        threading.Thread(target=clone_task).start()
+
+        timeout = 60
+
+        while True:
+            item = progress.queue.get(True)  # , timeout)
+            if item is None:
+                break
+            yield item
+
+        logging.info("Repo {} initialized".format(self.repo_dir))
 
 
 class SyncHandlerBase(JupyterHandler):
@@ -78,7 +139,7 @@ class SyncHandlerBase(JupyterHandler):
             )
             repo_dir = os.path.join(repo_parent_dir, targetpath or repo.split("/")[-1])
 
-            gp = GitPuller(
+            gp = ProgressGitPuller(
                 repo,
                 repo_dir,
                 branch=branch,
@@ -104,10 +165,6 @@ class SyncHandlerBase(JupyterHandler):
 
     async def emit(self, data: dict):
         serialized_data = json.dumps(data)
-        if "output" in data:
-            self.log.info(data["output"])
-        else:
-            self.log.info(data)
         self.write("data: {}\n\n".format(serialized_data))
         await self.flush()
 
@@ -137,6 +194,12 @@ class SyncHandlerBase(JupyterHandler):
                 if progress is None:
                     msg = {"phase": "finished", "exhibit_id": exhibit_id}
                     del self.settings["pull_status_queues"][exhibit_id]
+                elif isinstance(progress, dict):
+                    msg = {
+                        "output": progress,
+                        "phase": "progress",
+                        "exhibit_id": exhibit_id,
+                    }
                 elif isinstance(progress, Exception):
                     msg = {
                         "phase": "error",

--- a/jupyterlab_gallery/manager.py
+++ b/jupyterlab_gallery/manager.py
@@ -1,7 +1,10 @@
+from datetime import datetime
 from pathlib import Path
 
 from traitlets.config.configurable import LoggingConfigurable
 from traitlets import Dict, List, Unicode
+from subprocess import run
+import re
 
 
 def extract_repository_owner(git_url: str) -> str:
@@ -14,6 +17,22 @@ def extract_repository_name(git_url: str) -> str:
     if fragment.endswith(".git"):
         return fragment[:-4]
     return fragment
+
+
+def has_updates(repo_path: Path) -> bool:
+    result = run(
+        "git status -b --porcelain -u n --ignored n",
+        cwd=repo_path,
+        capture_output=True,
+        shell=True,
+    )
+    data = re.match(
+        r"^## (.*?)( \[(ahead (?P<ahead>\d+))?(, )?(behind (?P<behind>\d+))?\])?$",
+        result.stdout.decode("utf-8"),
+    )
+    if not data:
+        return False
+    return data["behind"] is not None
 
 
 class GalleryManager(LoggingConfigurable):
@@ -85,23 +104,14 @@ class GalleryManager(LoggingConfigurable):
         local_path = self.get_local_path(exhibit)
 
         data["localPath"] = str(local_path)
-        data["revision"] = "2a2f2ee779ac21b70339da6551c2f6b0b00f6efe"
-        # timestamp from .git/FETCH_HEAD of the cloned repo
-        data["lastUpdated"] = "2024-05-01"
-        data["currentTag"] = "v3.2.4"
-        # the UI can show that there are X updates available; it could also show
-        # a summary of the commits available, or tags available; possibly the name
-        # of the most recent tag and would be sufficient over sending the list of commits,
-        # which can be long and delay the initialization.
-        data["updatesAvailable"] = False
-        data["isCloned"] = local_path.exists()
-        data["newestTag"] = "v3.2.5"
-        data["updates"] = [
-            {
-                "revision": "02f04c339f880540064d2223176830afdd02f5fa",
-                "title": "commit description",
-                "description": "long commit description",
-                "date": "date in format returned by git",
-            }
-        ]
+        data["updatesAvailable"] = has_updates(local_path)
+        exists = local_path.exists()
+        data["isCloned"] = exists
+        if exists:
+            fetch_head = local_path / ".git" / "FETCH_HEAD"
+            if fetch_head.exists():
+                data["lastUpdated"] = datetime.fromtimestamp(
+                    fetch_head.stat().st_mtime
+                ).isoformat()
+
         return data

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "jupyterlab-gallery",
-    "version": "0.1.2",
+    "version": "0.1.3",
     "description": "A JupyterLab gallery extension for presenting and downloading examples from remote repositories",
     "keywords": [
         "jupyter",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,8 @@ classifiers = [
 ]
 dependencies = [
     "jupyter_server>=2.0.1,<3",
-    "nbgitpuller>=1.2.1"
+    "nbgitpuller>=1.2.1",
+    "GitPython>=3.1.43"
 ]
 dynamic = ["version", "description", "authors", "urls", "keywords"]
 

--- a/src/gallery.tsx
+++ b/src/gallery.tsx
@@ -1,6 +1,11 @@
 import * as React from 'react';
 import { ReactWidget, showErrorMessage } from '@jupyterlab/apputils';
-import { Button, UseSignal, folderIcon, downloadIcon } from '@jupyterlab/ui-components';
+import {
+  Button,
+  UseSignal,
+  folderIcon,
+  downloadIcon
+} from '@jupyterlab/ui-components';
 import { Contents } from '@jupyterlab/services';
 import { IStream, Stream, Signal } from '@lumino/signaling';
 import { TranslationBundle } from '@jupyterlab/translation';
@@ -151,7 +156,7 @@ function Gallery(props: {
 }
 
 interface IProgressState extends IProgress {
-  state?: 'error'
+  state?: 'error';
 }
 
 function Exhibit(props: {
@@ -178,10 +183,10 @@ function Exhibit(props: {
       }
       if (message.phase === 'progress') {
         setProgress(message.output);
-        setProgressMessage(message.output.message)
+        setProgressMessage(message.output.message);
       } else {
         const { output, phase } = message;
-        console.log(output + phase)
+        console.log(output + phase);
       }
     };
     props.progressStream.connect(listenToStreams);
@@ -196,12 +201,20 @@ function Exhibit(props: {
         <img src={exhibit.icon} alt={exhibit.title} />
       </div>
       <div className="jp-Exhibit-description">{exhibit.description}</div>
-      {progress ? <div className={"jp-Exhibit-progressbar" + (progress.state === 'error' ? " jp-Exhibit-progressbar-error" : "")}>
-        <div className="jp-Exhibit-progressbar-filler" style={{width: (progress.progress * 100) + '%'}}></div>
-        <div className="jp-Exhibit-progressMessage">
-          {progressMessage}
+      {progress ? (
+        <div
+          className={
+            'jp-Exhibit-progressbar' +
+            (progress.state === 'error' ? ' jp-Exhibit-progressbar-error' : '')
+          }
+        >
+          <div
+            className="jp-Exhibit-progressbar-filler"
+            style={{ width: progress.progress * 100 + '%' }}
+          ></div>
+          <div className="jp-Exhibit-progressMessage">{progressMessage}</div>
         </div>
-      </div> : null}
+      ) : null}
       <div className="jp-Exhibit-buttons">
         {!exhibit.isCloned ? (
           <Button
@@ -217,10 +230,10 @@ function Exhibit(props: {
                 setProgress(null);
               } catch {
                 setProgress({
-                  ...progress as any,
+                  ...(progress as any),
                   state: 'error'
                 });
-                setProgressMessage('')
+                setProgressMessage('');
               }
             }}
           >
@@ -242,22 +255,22 @@ function Exhibit(props: {
               minimal={true}
               title={props.trans.__('Fetch latest changes')}
               onClick={async () => {
-              setProgressMessage('Refreshing');
-              setProgress({
-                progress: 0.25,
-                message: 'Refreshing'
-              });
-              try {
-                await actions.download(exhibit);
-                setProgress(null);
-              } catch {
+                setProgressMessage('Refreshing');
                 setProgress({
-                  ...progress as any,
-                  state: 'error'
+                  progress: 0.25,
+                  message: 'Refreshing'
                 });
-                setProgressMessage('')
-              }
-            }}
+                try {
+                  await actions.download(exhibit);
+                  setProgress(null);
+                } catch {
+                  setProgress({
+                    ...(progress as any),
+                    state: 'error'
+                  });
+                  setProgressMessage('');
+                }
+              }}
             >
               <downloadIcon.react />
             </Button>

--- a/src/gallery.tsx
+++ b/src/gallery.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
 import { ReactWidget, showErrorMessage } from '@jupyterlab/apputils';
-import { Button, UseSignal } from '@jupyterlab/ui-components';
+import { Button, UseSignal, folderIcon, downloadIcon } from '@jupyterlab/ui-components';
 import { Contents } from '@jupyterlab/services';
 import { IStream, Stream, Signal } from '@lumino/signaling';
 import { TranslationBundle } from '@jupyterlab/translation';
 import { IExhibit } from './types';
 import { IExhibitReply } from './types';
-import { requestAPI, eventStream, IStreamMessage } from './handler';
+import { requestAPI, eventStream, IStreamMessage, IProgress } from './handler';
 
 interface IActions {
   download(exhibit: IExhibit): Promise<void>;
@@ -20,8 +20,9 @@ export class GalleryWidget extends ReactWidget {
     fileChanged: Contents.IManager['fileChanged'];
     refreshFileBrowser: () => Promise<void>;
   }) {
-    const { trans, fileChanged } = options;
     super();
+    const { trans, fileChanged } = options;
+    this._trans = trans;
     this._status = trans.__('Gallery loading...');
     this._actions = {
       open: async (exhibit: IExhibit) => {
@@ -109,6 +110,7 @@ export class GalleryWidget extends ReactWidget {
                 exhibits={this.exhibits}
                 actions={this._actions}
                 progressStream={this._stream}
+                trans={this._trans}
               />
             );
           }
@@ -119,6 +121,7 @@ export class GalleryWidget extends ReactWidget {
       </UseSignal>
     );
   }
+  private _trans: TranslationBundle;
   private _update = new Signal<GalleryWidget, void>(this);
   private _exhibits: IExhibit[] | null = null;
   private _status: string;
@@ -130,11 +133,13 @@ function Gallery(props: {
   exhibits: IExhibit[];
   actions: IActions;
   progressStream: IStream<GalleryWidget, IStreamMessage>;
+  trans: TranslationBundle;
 }): JSX.Element {
   return (
     <div className="jp-Gallery">
       {props.exhibits.map(exhibit => (
         <Exhibit
+          trans={props.trans}
           key={exhibit.repository}
           exhibit={exhibit}
           actions={props.actions}
@@ -145,13 +150,19 @@ function Gallery(props: {
   );
 }
 
+interface IProgressState extends IProgress {
+  state?: 'error'
+}
+
 function Exhibit(props: {
   exhibit: IExhibit;
   actions: IActions;
   progressStream: IStream<GalleryWidget, IStreamMessage>;
+  trans: TranslationBundle;
 }): JSX.Element {
   const { exhibit, actions } = props;
-  const [progressMessage, setProgressMessage] = React.useState<string>();
+  const [progress, setProgress] = React.useState<IProgressState | null>(null);
+  const [progressMessage, setProgressMessage] = React.useState<string>('');
 
   React.useEffect(() => {
     const listenToStreams = (_: GalleryWidget, message: IStreamMessage) => {
@@ -164,9 +175,13 @@ function Exhibit(props: {
           'Could not download',
           message.output ?? 'Unknown error'
         );
+      }
+      if (message.phase === 'progress') {
+        setProgress(message.output);
+        setProgressMessage(message.output.message)
       } else {
         const { output, phase } = message;
-        setProgressMessage(output ? phase + ': ' + output : phase);
+        console.log(output + phase)
       }
     };
     props.progressStream.connect(listenToStreams);
@@ -177,31 +192,77 @@ function Exhibit(props: {
   return (
     <div className="jp-Exhibit">
       <h4 className="jp-Exhibit-title">{exhibit.title}</h4>
-      <img src={exhibit.icon} className="jp-Exhibit-icon" alt={exhibit.title} />
+      <div className="jp-Exhibit-icon">
+        <img src={exhibit.icon} alt={exhibit.title} />
+      </div>
       <div className="jp-Exhibit-description">{exhibit.description}</div>
-      {progressMessage}
+      {progress ? <div className={"jp-Exhibit-progressbar" + (progress.state === 'error' ? " jp-Exhibit-progressbar-error" : "")}>
+        <div className="jp-Exhibit-progressbar-filler" style={{width: (progress.progress * 100) + '%'}}></div>
+        <div className="jp-Exhibit-progressMessage">
+          {progressMessage}
+        </div>
+      </div> : null}
       <div className="jp-Exhibit-buttons">
         {!exhibit.isCloned ? (
           <Button
+            title={props.trans.__('Set up')}
             onClick={async () => {
               setProgressMessage('Downloading');
-              await actions.download(exhibit);
+              setProgress({
+                progress: 0.01,
+                message: 'Initializing'
+              });
+              try {
+                await actions.download(exhibit);
+                setProgress(null);
+              } catch {
+                setProgress({
+                  ...progress as any,
+                  state: 'error'
+                });
+                setProgressMessage('')
+              }
             }}
           >
-            Setup up
+            <downloadIcon.react />
           </Button>
         ) : (
-          <Button
-            onClick={() => {
-              actions.open(exhibit);
+          <>
+            <Button
+              minimal={true}
+              title={props.trans.__('Open')}
+              onClick={() => {
+                actions.open(exhibit);
+              }}
+            >
+              <folderIcon.react />
+            </Button>
+            <Button
+              disabled={!exhibit.updatesAvailable}
+              minimal={true}
+              title={props.trans.__('Fetch latest changes')}
+              onClick={async () => {
+              setProgressMessage('Refreshing');
+              setProgress({
+                progress: 0.25,
+                message: 'Refreshing'
+              });
+              try {
+                await actions.download(exhibit);
+                setProgress(null);
+              } catch {
+                setProgress({
+                  ...progress as any,
+                  state: 'error'
+                });
+                setProgressMessage('')
+              }
             }}
-          >
-            Open
-          </Button>
+            >
+              <downloadIcon.react />
+            </Button>
+          </>
         )}
-        {exhibit.isCloned && exhibit.updatesAvailable ? (
-          <Button>Update</Button>
-        ) : null}
       </div>
     </div>
   );

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -47,7 +47,7 @@ export async function requestAPI<T>(
 
 export interface IProgress {
   progress: number;
-  message: string
+  message: string;
 }
 
 export interface IProgressStreamMessage {

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -45,11 +45,24 @@ export async function requestAPI<T>(
   return data;
 }
 
-export interface IStreamMessage {
-  output?: string;
-  phase: string;
+export interface IProgress {
+  progress: number;
+  message: string
+}
+
+export interface IProgressStreamMessage {
+  output: IProgress;
+  phase: 'progress';
   exhibit_id: number;
 }
+
+export interface ITextStreamMessage {
+  output?: string;
+  phase: 'error' | 'finished' | 'syncing';
+  exhibit_id: number;
+}
+
+export type IStreamMessage = IProgressStreamMessage | ITextStreamMessage;
 
 export function eventStream(
   endPoint = '',

--- a/style/base.css
+++ b/style/base.css
@@ -17,12 +17,54 @@
 
 .jp-Exhibit-description {
   padding: 2px;
+  height: 2.15em;
+  overflow: hidden;
+}
+
+.jp-Exhibit-icon > img {
+  max-width: 100%;
 }
 
 .jp-Exhibit-icon {
-  max-width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 
 .jp-Launcher-openExample .jp-Gallery {
   display: contents;
+}
+
+.jp-Exhibit-progressbar-filler {
+  background: var(--jp-success-color2);
+  height: 1em;
+  transition: width 1s;
+}
+
+.jp-Exhibit-progressbar {
+  border: 1px solid var(--jp-layout-color3);
+  background: var(--jp-layout-color2);
+  width: 100%;
+  margin-bottom: 10px;
+  border-radius: 2px;
+  position: relative;
+}
+
+.jp-Exhibit-progressbar-filler > .jp-Exhibit-progressbar-error {
+  background: var(--jp-error-color1);
+}
+
+.jp-Exhibit-progressMessage {
+  color: black;
+  max-height: 1.2em;
+  font-size: 85%;
+  position: absolute;
+  top: 0;
+  padding: 0 2px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.jp-Exhibit-buttons .jp-Button:disabled {
+  opacity: 0.3;
 }


### PR DESCRIPTION
Closes https://github.com/nebari-dev/jupyterlab-gallery/issues/6

Adds dependency on git-python

The GIF demonstrates:
- progress bar on pull
- then I revert to a previous revision using jupyterlab-git
- refresh page 
- the pull button is again active
- clicking it now uses the nbgitpuller logic to pull the latest version - the progress bar for this one is not very good yet, but it is generally much faster so should be less annoying

![new-progress-bar](https://github.com/nebari-dev/jupyterlab-gallery/assets/5832902/9a4f40ff-5f0d-4502-ba84-19a588295143)
