### PR TITLE
Hide gallery without exhibits

### DIFF
--- a/jupyterlab_gallery/handlers.py
+++ b/jupyterlab_gallery/handlers.py
@@ -27,7 +27,7 @@ class GalleryHandler(BaseHandler):
                 {
                     "title": self.gallery_manager.title,
                     "exhibitsConfigured": len(self.gallery_manager.exhibits) != 0,
-                    "hideGalleryWithoutExhibits": self.gallery_manager.hideGalleryWithoutExhibits,
+                    "hideGalleryWithoutExhibits": self.gallery_manager.hide_gallery_without_exhibits,
                     "apiVersion": "1.0",
                 }
             )

--- a/jupyterlab_gallery/handlers.py
+++ b/jupyterlab_gallery/handlers.py
@@ -27,6 +27,7 @@ class GalleryHandler(BaseHandler):
                 {
                     "title": self.gallery_manager.title,
                     "exhibitsConfigured": len(self.gallery_manager.exhibits) != 0,
+                    "hideGalleryWithoutExhibits": self.gallery_manager.hideGalleryWithoutExhibits,
                     "apiVersion": "1.0",
                 }
             )

--- a/jupyterlab_gallery/manager.py
+++ b/jupyterlab_gallery/manager.py
@@ -5,7 +5,7 @@ from typing import Optional
 from threading import Thread
 
 from traitlets.config.configurable import LoggingConfigurable
-from traitlets import Dict, List, Unicode
+from traitlets import Dict, List, Unicode, Bool
 
 from .git_utils import (
     extract_repository_owner,
@@ -67,6 +67,12 @@ class GalleryManager(LoggingConfigurable):
         help="The the display name of the Gallery widget",
         default_value="Gallery",
         config=True,
+    )
+
+    hideGalleryWithoutExhibits = Bool(
+        help="Hide Gallery if not exhibits are configured",
+        default_value=False,
+        config=True
     )
 
     def get_local_path(self, exhibit) -> Path:

--- a/jupyterlab_gallery/manager.py
+++ b/jupyterlab_gallery/manager.py
@@ -70,7 +70,7 @@ class GalleryManager(LoggingConfigurable):
     )
 
     hideGalleryWithoutExhibits = Bool(
-        help="Hide Gallery if not exhibits are configured",
+        help="Hide Gallery if no exhibits are configured",
         default_value=False,
         config=True
     )

--- a/jupyterlab_gallery/manager.py
+++ b/jupyterlab_gallery/manager.py
@@ -69,7 +69,7 @@ class GalleryManager(LoggingConfigurable):
         config=True,
     )
 
-    hideGalleryWithoutExhibits = Bool(
+    hide_gallery_without_exhibits = Bool(
         help="Hide Gallery if no exhibits are configured",
         default_value=False,
         config=True

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,8 +61,10 @@ const plugin: JupyterFrontEndPlugin<void> = {
         `jupyter-gallery API version out of sync, expected ${expectedVersion}, got ${data.apiVersion}`
       );
     }
-
     const title = data.title === 'Gallery' ? trans.__('Gallery') : data.title;
+    
+    // hide the widget if no exhibits are configured
+    if (data.hideGalleryWithoutExhibits && !data.exhibitsConfigured) { return }
     // add the widget to sidebar before waiting for server reply to reduce UI jitter
     if (launcher && isNewLauncher(launcher) && data.exhibitsConfigured) {
       launcher.addSection({
@@ -83,6 +85,7 @@ const plugin: JupyterFrontEndPlugin<void> = {
       widget.show();
       app.shell.add(widget, 'left', { rank: 850 });
     }
+
 
     try {
       const settings = await settingRegistry.load(plugin.id);

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,6 +65,7 @@ const plugin: JupyterFrontEndPlugin<void> = {
 
     // hide the widget if no exhibits are configured
     if (data.hideGalleryWithoutExhibits && !data.exhibitsConfigured) {
+      console.log('Gallery extension will not add any UI elements because no exhibits are configured');
       return;
     }
     // add the widget to sidebar before waiting for server reply to reduce UI jitter

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,9 +62,11 @@ const plugin: JupyterFrontEndPlugin<void> = {
       );
     }
     const title = data.title === 'Gallery' ? trans.__('Gallery') : data.title;
-    
+
     // hide the widget if no exhibits are configured
-    if (data.hideGalleryWithoutExhibits && !data.exhibitsConfigured) { return }
+    if (data.hideGalleryWithoutExhibits && !data.exhibitsConfigured) {
+      return;
+    }
     // add the widget to sidebar before waiting for server reply to reduce UI jitter
     if (launcher && isNewLauncher(launcher) && data.exhibitsConfigured) {
       launcher.addSection({
@@ -85,7 +87,6 @@ const plugin: JupyterFrontEndPlugin<void> = {
       widget.show();
       app.shell.add(widget, 'left', { rank: 850 });
     }
-
 
     try {
       const settings = await settingRegistry.load(plugin.id);

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,7 +68,7 @@ const plugin: JupyterFrontEndPlugin<void> = {
       return;
     }
     // add the widget to sidebar before waiting for server reply to reduce UI jitter
-    if (launcher && isNewLauncher(launcher) && data.exhibitsConfigured) {
+    if (launcher && isNewLauncher(launcher)) {
       launcher.addSection({
         title,
         className: 'jp-Launcher-openExample',

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,7 +65,9 @@ const plugin: JupyterFrontEndPlugin<void> = {
 
     // hide the widget if no exhibits are configured
     if (data.hideGalleryWithoutExhibits && !data.exhibitsConfigured) {
-      console.log('Gallery extension will not add any UI elements because no exhibits are configured');
+      console.log(
+        'Gallery extension will not add any UI elements because no exhibits are configured'
+      );
       return;
     }
     // add the widget to sidebar before waiting for server reply to reduce UI jitter

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,7 @@ export interface IGalleryReply {
   title: string;
   apiVersion: string;
   exhibitsConfigured: boolean;
+  hideGalleryWithoutExhibits: boolean;
 }
 
 export interface IExhibitReply {


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://nebari.dev/community
-->

## Reference Issues or PRs

Fixes #18
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create a link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

## What does this implement/fix?

Adds a configuration setting `hideGalleryWithoutExhibits`. When set to True and no exhibits are configured, the gallery panel will not be displayed in JupyterLab. When set to False, the gallery will be displayed whether any exhibits are configured or not. By default it is set to False.

_Put a `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

- [x] Did you test the pull request locally?
- [ ] Did you add new tests?

## Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Nebari Internals docs.
  - If no docs exist:
    - Create a stub for documentation, including bullet points for how to use the feature, code snippets (including from
      happy path tests), etc.
We want to ensure that the content produced for Nebari is accessible; if you are making significant contributions,
please address the access-centred guidelines in your content and complete our checklist. Thanks to @isabela-pf for this checklist :)
-->

### Access-centered content checklist

#### Text styling

- [ ] The content is written with [plain language](https://www.plainlanguage.gov/guidelines/) (where relevant).
- [ ] If there are headers, they use the proper header tags (with only one level-one header: `H1` or `#` in markdown).
- [ ] All links describe where they link to (for example, check the [Nebari website](https://nebari.dev/)).
- [ ] This content adheres to the Nebari style guides.

#### Non-text content

- [ ] All content is represented as text (for example, images need alt text, and videos need captions or descriptive transcripts).
- [ ] If there are emojis, there are not more than three in a row.
- [ ] Don't use [flashing GIFs or videos](https://www.w3.org/TR/UNDERSTANDING-WCAG20/seizure-does-not-violate.html).
- [ ] If the content were to be read as plain text, it still makes sense, and no information is missing.

## Any other comments?

<!--
Please be aware that we are a loose team of volunteers, so patience is necessary;
assistance handling other issues is very welcome.
We value all user contributions. If we are slow to review, either the pull request needs some benchmarking, tinkering,
convincing, etc., or the reviewers are likely busy. In either case,
we ask for your understanding during the
review process.
Thanks for contributing to Nebari 🙏🏼!
-->
