### PR TITLE
Investigate the `xsrf` token issue

### DIFF
--- a/jupyterlab_gallery/handlers.py
+++ b/jupyterlab_gallery/handlers.py
@@ -63,7 +63,12 @@ class PullHandler(BaseHandler, SyncHandlerBase):
     async def post(self):
         data = self.get_json_body()
         exhibit_id = data["exhibit_id"]
-        exhibit = self.gallery_manager.exhibits[exhibit_id]
+        try:
+            exhibit = self.gallery_manager.exhibits[exhibit_id]
+        except IndexError:
+            self.set_status(406)
+            self.finish(json.dumps({"message": f"exhibit_id {exhibit_id} not found"}))
+            return
         return await super()._pull(
             repo=exhibit["git"],
             exhibit_id=exhibit_id,

--- a/jupyterlab_gallery/tests/test_handlers.py
+++ b/jupyterlab_gallery/tests/test_handlers.py
@@ -1,5 +1,7 @@
 import json
 
+from jupyter_server.utils import url_path_join
+
 
 async def test_exhibits(jp_fetch):
     response = await jp_fetch("jupyterlab-gallery", "exhibits")
@@ -13,3 +15,20 @@ async def test_gallery(jp_fetch):
     assert response.code == 200
     payload = json.loads(response.body)
     assert payload["apiVersion"] == "1.0"
+
+
+async def test_pull_token_can_be_used_instead_of_xsrf(jp_serverapp, jp_base_url, http_server_client):
+    token = jp_serverapp.identity_provider.token
+    response = await http_server_client.fetch(
+        url_path_join(jp_base_url, "jupyterlab-gallery", "pull"),
+        body=b'{"exhibit_id": 100}',
+        method="POST",
+        headers={
+            "Authorization": f"token {token}",
+            "Cookie": ""
+        },
+        raise_error=False,
+    )
+    assert response.code == 406
+    payload = json.loads(response.body)
+    assert payload["message"] == "exhibit_id 100 not found"

--- a/src/gallery.tsx
+++ b/src/gallery.tsx
@@ -53,9 +53,16 @@ export class GalleryWidget extends ReactWidget {
           };
           this._stream.connect(promiseResolver);
         });
+        const xsrfTokenMatch = document.cookie.match('\\b_xsrf=([^;]*)\\b');
+        const args: Record<string, string | number> = {
+          exhibit_id: exhibit.id
+        };
+        if (xsrfTokenMatch) {
+          args['_xsrf'] = xsrfTokenMatch[1];
+        }
         await requestAPI('pull', {
           method: 'POST',
-          body: JSON.stringify({ exhibit_id: exhibit.id })
+          body: JSON.stringify(args)
         });
         await done;
       }

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -70,11 +70,17 @@ export function eventStream(
   onError: (error: Event) => void
 ): EventSource {
   const settings = ServerConnection.makeSettings();
-  const requestUrl = URLExt.join(
+  let requestUrl = URLExt.join(
     settings.baseUrl,
     'jupyterlab-gallery', // API Namespace
     endPoint
   );
+  const xsrfTokenMatch = document.cookie.match('\\b_xsrf=([^;]*)\\b');
+  if (xsrfTokenMatch) {
+    const fullUrl = new URL(requestUrl);
+    fullUrl.searchParams.append('_xsrf', xsrfTokenMatch[1]);
+    requestUrl = fullUrl.toString();
+  }
   const eventSource = new EventSource(requestUrl);
   eventSource.addEventListener('message', event => {
     const data = JSON.parse(event.data);


### PR DESCRIPTION
Fixes https://github.com/nebari-dev/jupyterlab-gallery/issues/26

- [x] Add test for `xsrf` token not being required in jupyter-server
- [x] Fix the issue that arises when used in JupyterHub