### PR TITLE
Set min-width on placeholder

### DIFF
--- a/style/base.css
+++ b/style/base.css
@@ -44,7 +44,7 @@
 }
 
 .jp-Exhibit-icon > .jp-exhibitPlaceholder > svg {
-  max-width: 100%;
+  min-width: 40px;
   block-size: 100%;
 }
 


### PR DESCRIPTION
## Reference Issues or PRs

Follow-up to https://github.com/nebari-dev/jupyterlab-gallery/pull/31 based on feedback that the placeholder icon is too small when only one exhibit is present

## What does this implement/fix?

_Put a `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

- [x] Did you test the pull request locally?
- [ ] Did you add new tests?
