### PR TITLE
Populate exhibit icon GitHub placeholder if specified but empty 

### DIFF
--- a/jupyterlab_gallery/manager.py
+++ b/jupyterlab_gallery/manager.py
@@ -90,7 +90,7 @@ class GalleryManager(LoggingConfigurable):
     def get_exhibit_data(self, exhibit):
         data = {}
 
-        if "icon" not in exhibit:
+        if "icon" not in exhibit or not exhibit["icon"]:
             homepage = exhibit.get("homepage")
             if homepage and homepage.startswith("https://github.com/"):
                 repository_name = extract_repository_name(exhibit["git"])

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "jupyterlab-gallery",
-    "version": "0.3.2",
+    "version": "0.3.3",
     "description": "A JupyterLab gallery extension for presenting and downloading examples from remote repositories",
     "keywords": [
         "jupyter",


### PR DESCRIPTION
Check for the icon specification being empty to attempt fixing GitHub icon placeholder