### PR TITLE
Pass token authorization for SSE using MS implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "jupyterlab-gallery",
-    "version": "0.6.2",
+    "version": "0.6.3",
     "description": "A JupyterLab gallery extension for presenting and downloading examples from remote repositories",
     "keywords": [
         "jupyter",
@@ -61,7 +61,8 @@
         "@jupyterlab/application": "^4.0.0",
         "@jupyterlab/coreutils": "^6.0.0",
         "@jupyterlab/services": "^7.0.0",
-        "@jupyterlab/settingregistry": "^4.0.0"
+        "@jupyterlab/settingregistry": "^4.0.0",
+        "@microsoft/fetch-event-source": "^2.0.1"
     },
     "devDependencies": {
         "@jupyterlab/builder": "^4.0.0",

--- a/src/gallery.tsx
+++ b/src/gallery.tsx
@@ -12,7 +12,13 @@ import { IStream, Stream, Signal } from '@lumino/signaling';
 import { TranslationBundle } from '@jupyterlab/translation';
 import { IExhibit } from './types';
 import { IExhibitReply } from './types';
-import { requestAPI, eventStream, IStreamMessage, IProgress } from './handler';
+import {
+  requestAPI,
+  eventStream,
+  IStreamMessage,
+  IProgress,
+  IEventStream
+} from './handler';
 import { repositoryIcon } from './icons';
 
 interface IActions {
@@ -103,7 +109,7 @@ export class GalleryWidget extends ReactWidget {
     }
   };
 
-  private _eventSource: EventSource;
+  private _eventSource: IEventStream;
 
   private async _load() {
     try {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3285,6 +3285,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@microsoft/fetch-event-source@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "@microsoft/fetch-event-source@npm:2.0.1"
+  checksum: a50e1c0f33220206967266d0a4bbba0703e2793b079d9f6e6bfd48f71b2115964a803e14cf6e902c6fab321edc084f26022334f5eaacc2cec87f174715d41852
+  languageName: node
+  linkType: hard
+
 "@nodelib/fs.scandir@npm:2.1.5":
   version: 2.1.5
   resolution: "@nodelib/fs.scandir@npm:2.1.5"
@@ -7454,6 +7461,7 @@ __metadata:
     "@jupyterlab/services": ^7.0.0
     "@jupyterlab/settingregistry": ^4.0.0
     "@jupyterlab/testutils": ^4.0.0
+    "@microsoft/fetch-event-source": ^2.0.1
     "@types/jest": ^29.2.0
     "@types/json-schema": ^7.0.11
     "@types/react": ^18.0.26


### PR DESCRIPTION
## Reference Issues or PRs

Uses `@microsoft/fetch-event-source` implementation of event streams which allows to pass additional headers. It also uses page visibility API to close the connections when not needed, reducing the server load.

This allows to pass the token along which is required to authorize with JupyterHub when running on a different server than the main one.

## What does this implement/fix?

_Put a `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

- [x] Did you test the pull request locally?
- [ ] Did you add new tests?
