### PR TITLE
Remove no-longer needed inclusion of xsrf token

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "jupyterlab-gallery",
-    "version": "0.6.3",
+    "version": "0.6.4",
     "description": "A JupyterLab gallery extension for presenting and downloading examples from remote repositories",
     "keywords": [
         "jupyter",

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -74,13 +74,7 @@ export function eventStream(
   namespace: string
 ): IEventStream {
   const settings = ServerConnection.makeSettings();
-  let requestUrl = URLExt.join(settings.baseUrl, namespace, endPoint);
-  const xsrfTokenMatch = document.cookie.match('\\b_xsrf=([^;]*)\\b');
-  if (xsrfTokenMatch) {
-    const fullUrl = new URL(requestUrl);
-    fullUrl.searchParams.append('_xsrf', xsrfTokenMatch[1]);
-    requestUrl = fullUrl.toString();
-  }
+  const requestUrl = URLExt.join(settings.baseUrl, namespace, endPoint);
   const controller = new AbortController();
   const promise = fetchEventSource(requestUrl, {
     onmessage: event => {


### PR DESCRIPTION
This is no longer needed because the token is now included; in fact the inclusion now prevents the second instance from accepting the request.


## Reference Issues or PRs

Follow-up to https://github.com/nebari-dev/jupyterlab-gallery/pull/44

## What does this implement/fix?

_Put a `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

- [ ] Did you test the pull request locally?
- [ ] Did you add new tests?
