### PR TITLE
Issue29/update on rename

### DIFF
--- a/jupyterlab_gallery/handlers.py
+++ b/jupyterlab_gallery/handlers.py
@@ -1,5 +1,6 @@
 import json
 from typing import cast
+from pathlib import Path
 
 from jupyter_server.base.handlers import APIHandler
 from .gitpuller import SyncHandlerBase
@@ -37,6 +38,24 @@ class GalleryHandler(BaseHandler):
 class ExhibitsHandler(BaseHandler):
     @tornado.web.authenticated
     def get(self):
+        self.finish(
+            json.dumps(
+                {
+                    "exhibits": [
+                        self._prepare_exhibit(exhibit_config, exhibit_id=i)
+                        for i, exhibit_config in enumerate(
+                            self.gallery_manager.exhibits
+                        )
+                    ]
+                }
+            )
+        )
+
+    @tornado.web.authenticated
+    def post(self):
+        data = self.get_json_body()
+        new_path = Path(data["new_path"])
+        updated_exhibits = self.gallery_manager.update_exhibit_paths(new_path)
         self.finish(
             json.dumps(
                 {

--- a/jupyterlab_gallery/handlers.py
+++ b/jupyterlab_gallery/handlers.py
@@ -62,7 +62,7 @@ class ExhibitsHandler(BaseHandler):
                     "exhibits": [
                         self._prepare_exhibit(exhibit_config, exhibit_id=i)
                         for i, exhibit_config in enumerate(
-                            self.gallery_manager.exhibits
+                            updated_exhibits
                         )
                     ]
                 }

--- a/jupyterlab_gallery/manager.py
+++ b/jupyterlab_gallery/manager.py
@@ -55,6 +55,11 @@ class GalleryManager(LoggingConfigurable):
                 "depth": Int(
                     default_value=None, help="Depth of the clone", allow_none=True
                 ),
+                "destination": Unicode(
+                    help="Folder to clone the repository into", 
+                    allow_none=True,
+                    default_value=None
+                )
                 # other ideas: `path_in_repository`, `documentation_url`
             }
         ),
@@ -82,9 +87,29 @@ class GalleryManager(LoggingConfigurable):
     )
 
     def get_local_path(self, exhibit) -> Path:
-        clone_destination = Path(self.destination)
+        if exhibit.get("destination") is not None:
+            clone_destination = Path(exhibit["destination"])
+        else:
+            clone_destination = Path(self.destination) 
         repository_name = extract_repository_name(exhibit["git"])
         return clone_destination / repository_name
+    
+    def update_exhibit_paths(self, new_path: Path):
+        updated_exhibits = []
+        for exhibit in self.exhibits:
+            local_path = self.get_local_path(exhibit)
+            if not local_path.exists():
+                if new_path.exists():
+                    repository_name = extract_repository_name(exhibit["git"])
+                    if new_path.name == repository_name:
+                        exhibit["destination"] = str(new_path.parent)
+                    else:
+                        potential_path = new_path / repository_name
+                        if potential_path.exists():
+                            exhibit["destination"] = str(new_path)
+            updated_exhibits.append(exhibit)
+        self.exhibits = updated_exhibits
+        return updated_exhibits
 
     def _check_updates(self, exhibit):
         local_path = self.get_local_path(exhibit)

--- a/jupyterlab_gallery/tests/test_handlers.py
+++ b/jupyterlab_gallery/tests/test_handlers.py
@@ -1,5 +1,6 @@
 import json
 from unittest import mock
+from pathlib import Path
 import pytest
 
 from jupyter_server.utils import url_path_join
@@ -12,6 +13,49 @@ async def test_exhibits(jp_fetch):
     assert response.code == 200
     payload = json.loads(response.body)
     assert isinstance(payload["exhibits"], list)
+
+
+@pytest.mark.parametrize(
+    "exhibit",
+    [
+        {
+            "git": "https://github.com/nebari-dev/nebari.git",
+            "homepage": "https://github.com/nebari-dev/nebari",
+            "isCloned": True
+        },
+    ],
+)
+async def test_exhibits_post(jp_fetch, exhibit):
+    update = {
+        "new_path": "gallery",
+        "old_path": "examples"
+    }
+
+    def mocked_exists(path_instance):
+        if str(path_instance) in ["gallery", "gallery/nebari"]:
+            return True
+        else:
+            return False
+
+    def mocked_get_exhibit_data(_, exhibit):
+        output = {
+            "homepage": exhibit["homepage"],
+            "icon": None,
+            "localPath": exhibit["destination"],
+            "isCloned": True,
+        }
+        return output
+    
+    with mock.patch.object(GalleryManager, "exhibits", [exhibit]):
+        with mock.patch.object(GalleryManager, "destination", Path("example")):
+            with mock.patch.object(GalleryManager, "get_exhibit_data", mocked_get_exhibit_data):
+                with mock.patch.object(Path, "exists", mocked_exists):
+                    response = await jp_fetch("jupyterlab-gallery", "exhibits", method="POST", body=json.dumps(update))
+    assert response.code == 200
+    payload = json.loads(response.body)
+    breakpoint()
+    assert payload["exhibits"][0]["localPath"] == "gallery"
+    assert False
 
 
 @pytest.mark.parametrize(

--- a/jupyterlab_gallery/tests/test_handlers.py
+++ b/jupyterlab_gallery/tests/test_handlers.py
@@ -45,17 +45,15 @@ async def test_exhibits_post(jp_fetch, exhibit):
             "isCloned": True,
         }
         return output
-    
-    with mock.patch.object(GalleryManager, "exhibits", [exhibit]):
-        with mock.patch.object(GalleryManager, "destination", Path("example")):
-            with mock.patch.object(GalleryManager, "get_exhibit_data", mocked_get_exhibit_data):
-                with mock.patch.object(Path, "exists", mocked_exists):
-                    response = await jp_fetch("jupyterlab-gallery", "exhibits", method="POST", body=json.dumps(update))
+    with mock.patch.multiple(GalleryManager, 
+                        exhibits=[exhibit],
+                        destination=Path("example"),
+                        get_exhibit_data=mocked_get_exhibit_data):
+        with mock.patch.object(Path, "exists", mocked_exists):
+            response = await jp_fetch("jupyterlab-gallery", "exhibits", method="POST", body=json.dumps(update))
     assert response.code == 200
     payload = json.loads(response.body)
-    breakpoint()
     assert payload["exhibits"][0]["localPath"] == "gallery"
-    assert False
 
 
 @pytest.mark.parametrize(

--- a/src/gallery.tsx
+++ b/src/gallery.tsx
@@ -24,6 +24,7 @@ import { repositoryIcon } from './icons';
 interface IActions {
   download(exhibit: IExhibit): Promise<void>;
   open(exhibit: IExhibit): Promise<void>;
+  updateLocalPath(new_path: string): Promise<void>;
 }
 
 export class GalleryWidget extends ReactWidget {
@@ -73,11 +74,31 @@ export class GalleryWidget extends ReactWidget {
           body: JSON.stringify(args)
         });
         await done;
+      },
+      updateLocalPath: async (new_path: string) => {
+        const xsrfTokenMatch = document.cookie.match('\\b_xsrf=([^;]*)\\b');
+        const args: Record<string, string > = {
+          new_path: new_path
+        };
+        if (xsrfTokenMatch) {
+          args['_xsrf'] = xsrfTokenMatch[1];
+        }
+        await requestAPI('exhibits', this.options.serverAPI, {
+          method: 'POST',
+          body: JSON.stringify(args)
+        });
       }
     };
     // if user deletes a directory, reload the state
     fileChanged.connect((_, args) => {
       if (args.type === 'delete') {
+        this._load();
+      }
+      else if (args.type === 'rename') {
+        let newPath = args.newValue?.path
+        if (newPath) {
+          this._actions.updateLocalPath(newPath)
+        }
         this._load();
       }
     });

--- a/src/gallery.tsx
+++ b/src/gallery.tsx
@@ -77,7 +77,7 @@ export class GalleryWidget extends ReactWidget {
       },
       updateLocalPath: async (new_path: string) => {
         const xsrfTokenMatch = document.cookie.match('\\b_xsrf=([^;]*)\\b');
-        const args: Record<string, string > = {
+        const args: Record<string, string> = {
           new_path: new_path
         };
         if (xsrfTokenMatch) {
@@ -93,11 +93,10 @@ export class GalleryWidget extends ReactWidget {
     fileChanged.connect((_, args) => {
       if (args.type === 'delete') {
         this._load();
-      }
-      else if (args.type === 'rename') {
-        let newPath = args.newValue?.path
+      } else if (args.type === 'rename') {
+        const newPath = args.newValue?.path;
         if (newPath) {
-          this._actions.updateLocalPath(newPath)
+          this._actions.updateLocalPath(newPath);
         }
         this._load();
       }


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://nebari.dev/community
-->

## Reference Issues or PRs

Closes #29 

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create a link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

## What does this implement/fix?
_Put a `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds a feature)
- [x] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

Adds functionality to rename gallery directories and their parent directories. 


https://github.com/user-attachments/assets/8a430717-272c-4586-9640-e1bb499bb3b7



## Testing

- [x] Did you test the pull request locally?
- [ ] Did you add new tests?

## Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Nebari Internals docs.
  - If no docs exist:
    - Create a stub for documentation, including bullet points for how to use the feature, code snippets (including from
      happy path tests), etc.
We want to ensure that the content produced for Nebari is accessible; if you are making significant contributions,
please address the access-centred guidelines in your content and complete our checklist. Thanks to @isabela-pf for this checklist :)
-->

### Access-centered content checklist

#### Text styling

- [ ] The content is written with [plain language](https://www.plainlanguage.gov/guidelines/) (where relevant).
- [ ] If there are headers, they use the proper header tags (with only one level-one header: `H1` or `#` in markdown).
- [ ] All links describe where they link to (for example, check the [Nebari website](https://nebari.dev/)).
- [ ] This content adheres to the Nebari style guides.

#### Non-text content

- [ ] All content is represented as text (for example, images need alt text, and videos need captions or descriptive transcripts).
- [ ] If there are emojis, there are not more than three in a row.
- [ ] Don't use [flashing GIFs or videos](https://www.w3.org/TR/UNDERSTANDING-WCAG20/seizure-does-not-violate.html).
- [ ] If the content were to be read as plain text, it still makes sense, and no information is missing.

## Any other comments?

This works really well within a session, but the changes aren't reflected between sessions which I think is probably important. I'm unsure what the best way to keep between session state is. One idea would be to make the `destination` attribute of `Gallery Manager` a setting. This would be able to save state across sessions for the top level destination folder, but to keep each exhibits destination attribute added in this branch could easily lead to bad UX. Another idea would be to do a recursive search through the filesystem for the repo name if the repo doesn't exist in the expected location on load and assume that any exact matches are in fact the repo. This would work in most cases, but has the potential to slow down startup considerably and false positive matches could also be poor UX.

@krassowski, do you have any thoughts on this?

<!--
Please be aware that we are a loose team of volunteers, so patience is necessary;
assistance handling other issues is very welcome.
We value all user contributions. If we are slow to review, either the pull request needs some benchmarking, tinkering,
convincing, etc., or the reviewers are likely busy. In either case,
we ask for your understanding during the
review process.
Thanks for contributing to Nebari 🙏🏼!
-->
