### PR TITLE
adds exhibits_url and related functionality

### DIFF
--- a/jupyterlab_gallery/handlers.py
+++ b/jupyterlab_gallery/handlers.py
@@ -36,7 +36,8 @@ class GalleryHandler(BaseHandler):
 
 class ExhibitsHandler(BaseHandler):
     @tornado.web.authenticated
-    def get(self):
+    async def get(self):
+        await self.gallery_manager.get_exhibit_url_data()
         self.finish(
             json.dumps(
                 {

--- a/jupyterlab_gallery/manager.py
+++ b/jupyterlab_gallery/manager.py
@@ -3,9 +3,11 @@ from datetime import datetime
 from pathlib import Path
 from typing import Optional
 from threading import Thread
+import json
 
 from traitlets.config.configurable import LoggingConfigurable
 from traitlets import Dict, List, Unicode, Bool, Int
+from tornado.httpclient import AsyncHTTPClient
 
 from .git_utils import (
     extract_repository_owner,
@@ -63,6 +65,13 @@ class GalleryManager(LoggingConfigurable):
         default_value=[],
     )
 
+    exhibits_url = Unicode(
+        help="A url to a json or yaml file containing exhibits",
+        default_value=None,
+        allow_none=True,
+        config=True
+    )
+
     destination = Unicode(
         help="The directory into which the exhibits will be cloned",
         default_value="gallery",
@@ -92,6 +101,21 @@ class GalleryManager(LoggingConfigurable):
             account=exhibit.get("account"), token=exhibit.get("token")
         ):
             self._has_updates[local_path] = has_updates(local_path)
+
+    async def get_exhibit_url_data(self):
+        if self.exhibits_url:
+            http_client = AsyncHTTPClient()
+            response = await http_client.fetch(self.exhibits_url)
+            if not response.code == 200:
+                raise RuntimeError(
+                    f"Unable to fetch exhibits from {self.exhibits_url}"
+                )
+            content = json.loads(response.body)
+            content_exhibits = content.get("exhibits", [])
+            for exhibit in content_exhibits:
+                git = exhibit["git"]
+                if not any(e["git"] == git for e in self.exhibits):
+                    self.exhibits.append(exhibit)
 
     def get_exhibit_data(self, exhibit):
         data = {}

--- a/jupyterlab_gallery/tests/test_handlers.py
+++ b/jupyterlab_gallery/tests/test_handlers.py
@@ -1,10 +1,37 @@
 import json
 from unittest import mock
 import pytest
+import tornado
+import json
 
 from jupyter_server.utils import url_path_join
 
 from jupyterlab_gallery.manager import GalleryManager
+
+
+@pytest.fixture
+def exhibits_server(jp_asyncio_loop):
+    async def run_server():
+        content = {"exhibits": [
+            {
+                "git": "https://github.com/nebari-dev/jupyterlab-gallery.git",
+                "homepage": "https://github.com/nebari-dev/nebari",
+                "title": "jupyterlab-gallery"
+            }
+        ]}
+
+        class ExhibitsJsonHandler(tornado.web.RequestHandler):
+            def get(self):
+                self.write(content)
+
+        app = tornado.web.Application([(r"/exhibits.json", ExhibitsJsonHandler)])
+
+        server = app.listen(8030)
+        return server
+        
+    server = jp_asyncio_loop.run_until_complete(run_server())
+    yield "http://127.0.0.1:8030"
+    server.stop()
 
 
 async def test_exhibits(jp_fetch):
@@ -12,6 +39,15 @@ async def test_exhibits(jp_fetch):
     assert response.code == 200
     payload = json.loads(response.body)
     assert isinstance(payload["exhibits"], list)
+
+async def test_exhibits_with_exhibits_url(jp_fetch, exhibits_server):
+    url = exhibits_server
+    with mock.patch.object(GalleryManager, "exhibits_url", url + "/exhibits.json"):
+        response = await jp_fetch("jupyterlab-gallery", "exhibits")
+    assert response.code == 200
+    payload = json.loads(response.body)
+    assert len(payload["exhibits"]) == 1
+    assert payload["exhibits"][0]["title"] == "jupyterlab-gallery"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://nebari.dev/community
-->

## Reference Issues or PRs
Closes #15 

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create a link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

## What does this implement/fix?

_Put a `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds a feature)
- [x] (may be breaking as it changes api)Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

- [x] Did you test the pull request locally?
- [x] Did you add new tests?

## Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Nebari Internals docs.
  - If no docs exist:
    - Create a stub for documentation, including bullet points for how to use the feature, code snippets (including from
      happy path tests), etc.
We want to ensure that the content produced for Nebari is accessible; if you are making significant contributions,
please address the access-centred guidelines in your content and complete our checklist. Thanks to @isabela-pf for this checklist :)
-->

### Access-centered content checklist

#### Text styling

- [ ] The content is written with [plain language](https://www.plainlanguage.gov/guidelines/) (where relevant).
- [ ] If there are headers, they use the proper header tags (with only one level-one header: `H1` or `#` in markdown).
- [ ] All links describe where they link to (for example, check the [Nebari website](https://nebari.dev/)).
- [ ] This content adheres to the Nebari style guides.

#### Non-text content

- [ ] All content is represented as text (for example, images need alt text, and videos need captions or descriptive transcripts).
- [ ] If there are emojis, there are not more than three in a row.
- [ ] Don't use [flashing GIFs or videos](https://www.w3.org/TR/UNDERSTANDING-WCAG20/seizure-does-not-violate.html).
- [ ] If the content were to be read as plain text, it still makes sense, and no information is missing.

## Any other comments?

Note that there is no authentication for this. It is expected that the URL exists and that it is publically available. Can be tested with 

```bash
jupyter lab --dev-mode --extensions-in-dev-mode --GalleryManager.exhibits_url="https://gist.githubusercontent.com/andrewfulton9/9d8045535a320be3b81fa4b1f067f9f2/raw/a4b84fec553674ca62abc607b8e1cd4e57d9237a/exhibits_example.json"
```

<!--
Please be aware that we are a loose team of volunteers, so patience is necessary;
assistance handling other issues is very welcome.
We value all user contributions. If we are slow to review, either the pull request needs some benchmarking, tinkering,
convincing, etc., or the reviewers are likely busy. In either case,
we ask for your understanding during the
review process.
Thanks for contributing to Nebari 🙏🏼!
-->
